### PR TITLE
kernel: kshell: handle different backspaces

### DIFF
--- a/src/kernel/kshell/kshell.c
+++ b/src/kernel/kshell/kshell.c
@@ -157,7 +157,8 @@ void kshell(int argc, char* argv[])
         }
         break;
 
-      case '\b':
+      case 0x08:
+      case 0x7f:
         if (readline_index > 0) {
           // destructive backspace
           printf("\b \b");


### PR DESCRIPTION
This is needed to be able to support backspaces on a serial connection with minicom for instance. This will be required for raspi3 support given that there won't be a screen available at the beginning.