### PR TITLE
kernel: kshell: do not power off system when kshell receives arguments

### DIFF
--- a/src/kernel/kshell/kshell.c
+++ b/src/kernel/kshell/kshell.c
@@ -129,12 +129,11 @@ void kshell(int argc, char* argv[])
     for (int i = 1; i < argc; i++) {
       if (strcmp(argv[i], "selftest") == 0) {
         selftest();
+        power_off();
       } else {
-        printf("unsupported command: %s\n", argv[i]);
+        printf("kshell: unsupported argument: %s\n", argv[i]);
       }
     }
-
-    power_off();
   }
 
   printf("\nThis is " KERNEL_NAME " kernel shell. "


### PR DESCRIPTION
We only want to power off the system after having run the self tests.