### PR TITLE
kernel: kmain: panic when we cannot copy the original command line

### DIFF
--- a/src/kernel/kmain.c
+++ b/src/kernel/kmain.c
@@ -127,6 +127,10 @@ void kmain_start(const char* cmdline)
   // Keep a copy of the original command line.
   saved_cmdline = strdup(cmdline);
 
+  if (saved_cmdline == NULL) {
+    PANIC("failed to copy cmdline, is heap memory available?");
+  }
+
   run_initcalls();
 
   int argc = 0;


### PR DESCRIPTION
This would reveal a bug or that heap memory hasn't been setup correctly (also a bug).