### PR TITLE
docs: add a doxygen filter to handle TODOs

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -693,7 +693,7 @@ STRICT_PROTO_MATCHING  = NO
 # list. This list is created by putting \todo commands in the documentation.
 # The default value is: YES.
 
-GENERATE_TODOLIST      = NO
+GENERATE_TODOLIST      = YES
 
 # The GENERATE_TESTLIST tag can be used to enable (YES) or disable (NO) the test
 # list. This list is created by putting \test commands in the documentation.
@@ -997,7 +997,9 @@ INPUT_FILTER           =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-FILTER_PATTERNS        = *.md=tools/doxygenify-md-files.py
+FILTER_PATTERNS        = *.md=tools/doxygenify-md-files.py \
+                         *.c=tools/doxygen-todos.py \
+                         *.h=tools/doxygen-todos.py
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for

--- a/tools/doxygen-todos.py
+++ b/tools/doxygen-todos.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import re
+import sys
+
+with open(sys.argv[1], 'r') as file:
+    content = file.read()
+    # Replace 3-line comments with a TODO. It isn't pretty but it works...
+    content = re.sub(
+        '//\s+TODO:(.+?)(\n\s*)(//.+)(\n\s*)(//.+)',
+        '/// \\\\todo\g<1>\g<2>/\g<3>\g<4>/\g<5>',
+        content,
+        flags=re.S,
+    )
+    # Replace 2-line comments with a TODO.
+    content = re.sub(
+        '//\s+TODO:(.+?)(\n\s*)(//.+)',
+        '/// \\\\todo\g<1>\g<2>/\g<3>',
+        content,
+        flags=re.S,
+    )
+    # Single-line TODOs.
+    content = re.sub('//\s+TODO:', '/// \\\\todo', content)
+    print(content, end='')

--- a/tools/doxygenify-md-files.py
+++ b/tools/doxygenify-md-files.py
@@ -8,4 +8,4 @@ with open(sys.argv[1], 'r') as file:
     content = re.sub('<\!-- doxygen:(.+)-->', '\g<1>', content, flags=re.S)
     # Replace `Note:` with `\note` so that Doxygen can generate a nice card.
     content = content.replace('Note:', '\\note')
-    print(content)
+    print(content, end='')


### PR DESCRIPTION
Fixes https://github.com/willdurand/ArvernOS/issues/460

---

In order to create a TODO List page, we need to support the special
Doxygen syntax for TODOs. Given this is Doxygen-specific, we use a
Doxygen filter to modify the source on the fly.