### PR TITLE
kernel: aarch64: raspi3: add ISR+timer implementation

### DIFF
--- a/src/kernel/arch/aarch64/Makefile.include
+++ b/src/kernel/arch/aarch64/Makefile.include
@@ -26,6 +26,7 @@ ASM  = $(CC)
 libk_c_files   += $(wildcard $(kernel_src_dir)/core/arm/*.c)
 libk_c_files   += $(wildcard $(arch_src)/*.c)
 libk_c_files   += $(wildcard $(arch_src)/arch/*.c)
+libk_c_files   += $(wildcard $(arch_src)/core/*.c)
 libk_c_files   += $(wildcard $(arch_src)/sys/*.c)
 libk_asm_files += $(wildcard $(arch_src)/asm/*.asm)
 

--- a/src/kernel/arch/aarch64/arch/time.c
+++ b/src/kernel/arch/aarch64/arch/time.c
@@ -1,16 +1,49 @@
 #include <arch/time.h>
 
+#include <board.h>
+#include <core/isr.h>
+#include <core/mmio.h>
+#include <stdio.h>
 #include <time/fake_clock.h>
+
+void arch_timer_callback();
+
+static uint32_t interval_1 = 100000;
+static uint32_t current_value_1 = 0;
 
 void arch_timer_init()
 {
-  // TODO:
+  isr_register_handler(SYSTEM_TIMER_IRQ_1, arch_timer_callback);
+  mmio_write(ENABLE_IRQS_1, SYSTEM_TIMER_IRQ_1);
+
+  current_value_1 = mmio_read(TIMER_CLO);
+  current_value_1 += interval_1;
+
+  mmio_write(TIMER_C1, current_value_1);
+}
+
+void arch_timer_callback()
+{
+  current_value_1 += interval_1;
+
+  // TODO: It would probably be a good idea to handle overflows because we are
+  // using a uint32_t for the current value.
+
+  mmio_write(TIMER_C1, current_value_1);
+  mmio_write(TIMER_CS, TIMER_CS_M1);
 }
 
 uint64_t arch_timer_uptime_microseconds()
 {
-  // TODO:
-  return 0;
+  uint32_t hi = mmio_read(TIMER_CHI);
+  uint32_t lo = mmio_read(TIMER_CLO);
+
+  while (hi != mmio_read(TIMER_CHI)) {
+    hi = mmio_read(TIMER_CHI);
+    lo = mmio_read(TIMER_CLO);
+  }
+
+  return ((uint64_t)hi << 32) | lo;
 }
 
 void arch_clock_init()

--- a/src/kernel/arch/aarch64/board/raspi3/asm/isr.asm
+++ b/src/kernel/arch/aarch64/board/raspi3/asm/isr.asm
@@ -1,22 +1,119 @@
+// The `kernel_*` and `ventry` macros are based on Sergey Matyukevich's work,
+// released under a MIT license.
+//
+// See: https://github.com/s-matyukevich/raspberry-pi-os/blob/master/docs/lesson03/rpi-os.md
 .global vectors
 
-.macro ventry type label
+.macro ventry_exc type
   .align 7
   mov x0, \type
-  b \label
+  b call_exception_handler
+.endm
+
+.macro ventry_irq type
+  .align 7
+  b call_irq_handler
+.endm
+
+.macro kernel_entry
+  sub	sp, sp, #256
+  stp	x0, x1, [sp, #16 * 0]
+  stp	x2, x3, [sp, #16 * 1]
+  stp	x4, x5, [sp, #16 * 2]
+  stp	x6, x7, [sp, #16 * 3]
+  stp	x8, x9, [sp, #16 * 4]
+  stp	x10, x11, [sp, #16 * 5]
+  stp	x12, x13, [sp, #16 * 6]
+  stp	x14, x15, [sp, #16 * 7]
+  stp	x16, x17, [sp, #16 * 8]
+  stp	x18, x19, [sp, #16 * 9]
+  stp	x20, x21, [sp, #16 * 10]
+  stp	x22, x23, [sp, #16 * 11]
+  stp	x24, x25, [sp, #16 * 12]
+  stp	x26, x27, [sp, #16 * 13]
+  stp	x28, x29, [sp, #16 * 14]
+
+  mrs	x22, elr_el1
+  mrs	x23, spsr_el1
+
+  stp	x30, x22, [sp, #16 * 15]
+  str	x23, [sp, #16 * 16]
+.endm
+
+.macro kernel_exit
+  ldr	x23, [sp, #16 * 16]
+  ldp	x30, x22, [sp, #16 * 15]
+
+  msr	elr_el1, x22
+  msr	spsr_el1, x23
+
+  ldp	x0, x1, [sp, #16 * 0]
+  ldp	x2, x3, [sp, #16 * 1]
+  ldp	x4, x5, [sp, #16 * 2]
+  ldp	x6, x7, [sp, #16 * 3]
+  ldp	x8, x9, [sp, #16 * 4]
+  ldp	x10, x11, [sp, #16 * 5]
+  ldp	x12, x13, [sp, #16 * 6]
+  ldp	x14, x15, [sp, #16 * 7]
+  ldp	x16, x17, [sp, #16 * 8]
+  ldp	x18, x19, [sp, #16 * 9]
+  ldp	x20, x21, [sp, #16 * 10]
+  ldp	x22, x23, [sp, #16 * 11]
+  ldp	x24, x25, [sp, #16 * 12]
+  ldp	x26, x27, [sp, #16 * 13]
+  ldp	x28, x29, [sp, #16 * 14]
+  add	sp, sp, #256
+  eret
 .endm
 
 .align 11
 vectors:
   // EL1t: synchronous
-  ventry #0 exception_handler
+  ventry_exc #0
   // EL1t: IRQ
-  ventry #1 exception_handler
+  ventry_exc #1
   // EL1t: FIQ
-  ventry #2 exception_handler
+  ventry_exc #2
   // EL1t: SError
-  ventry #3 exception_handler
-  // TODO: add the other vector entries (for EL1h, EL0 64bit and 32bit)
+  ventry_exc #3
 
-exception_handler:
-  eret
+  // EL1h: synchronous
+  ventry_exc #4
+  // EL1h: IRQ
+  ventry_irq #5
+  // EL1h: FIQ
+  ventry_irq #6
+  // EL1h: SError
+  ventry_exc #7
+
+  // 64bit EL0: synchronous
+  ventry_exc #8
+  // 64bit EL0: IRQ
+  ventry_exc #9
+  // 64bit EL0: FIQ
+  ventry_exc #10
+  // 64bit EL0: SError
+  ventry_exc #11
+
+  // 32bit EL0: synchronous
+  ventry_exc #12
+  // 32bit EL0: IRQ
+  ventry_exc #13
+  // 32bit EL0: FIQ
+  ventry_exc #14
+  // 32bit EL0: SError
+  ventry_exc #15
+
+call_exception_handler:
+  kernel_entry
+  bl isr_exception_handler
+  b hang
+
+call_irq_handler:
+  kernel_entry
+  bl isr_irq_handler
+  kernel_exit
+
+hang:
+  wfe
+  b hang

--- a/src/kernel/arch/aarch64/board/raspi3/board.h
+++ b/src/kernel/arch/aarch64/board/raspi3/board.h
@@ -29,4 +29,16 @@
 #define AUX_MU_STAT    (MMIO_BASE + 0x00215064)
 #define AUX_MU_BAUD    (MMIO_BASE + 0x00215068)
 
+// interrupts
+#define IRQ_PENDING_1      (MMIO_BASE + 0x0000B204)
+#define ENABLE_IRQS_1      (MMIO_BASE + 0x0000B210)
+#define SYSTEM_TIMER_IRQ_1 (1 << 1)
+
+// timer
+#define TIMER_CS    (MMIO_BASE + 0x00003000)
+#define TIMER_CLO   (MMIO_BASE + 0x00003004)
+#define TIMER_CHI   (MMIO_BASE + 0x00003008)
+#define TIMER_C1    (MMIO_BASE + 0x00003010)
+#define TIMER_CS_M1 (1 << 1)
+
 #endif

--- a/src/kernel/arch/aarch64/board/raspi3/kmain.c
+++ b/src/kernel/arch/aarch64/board/raspi3/kmain.c
@@ -1,5 +1,6 @@
 #include "kmain.h"
 #include <core/arm/atag.h>
+#include <core/isr.h>
 #include <drivers/miniuart.h>
 #include <fs/tar.h>
 #include <fs/vfs.h>
@@ -24,6 +25,10 @@ void kmain(uintptr_t w0)
   } else {
     DEBUG("w0=%p but we do not support DTB", w0);
   }
+
+  print_step("initializing interrupt service routine");
+  isr_init();
+  print_ok();
 
   print_step("initializing heap allocator");
   // nothing to do for now

--- a/src/kernel/arch/aarch64/core/isr.c
+++ b/src/kernel/arch/aarch64/core/isr.c
@@ -1,0 +1,53 @@
+#include "isr.h"
+#include <board.h>
+#include <core/logging.h>
+#include <core/mmio.h>
+
+static isr_handler_t handlers[16] = { 0 };
+
+void isr_init()
+{
+  isr_enable_interrupts();
+}
+
+/**
+ * Enables hardware interrupts.
+ */
+void isr_enable_interrupts()
+{
+  __asm__("msr daifclr, #2");
+}
+
+/**
+ * Disables hardware interrupts.
+ */
+void isr_disable_interrupts()
+{
+  __asm__("msr daifset, #2");
+}
+
+void isr_irq_handler()
+{
+  uint32_t id = mmio_read(IRQ_PENDING_1);
+
+  if (handlers[id] != 0) {
+    isr_handler_t handler = handlers[id];
+    handler();
+  } else {
+    DEBUG("unknown pending IRQ: id=%ld", id);
+  }
+}
+
+void isr_exception_handler(uint8_t type)
+{
+  ERROR("exception handler invoked: type=%d", type);
+
+  while (1) {
+    ;
+  }
+}
+
+void isr_register_handler(uint32_t id, isr_handler_t handler)
+{
+  handlers[id] = handler;
+}

--- a/src/kernel/arch/aarch64/core/isr.h
+++ b/src/kernel/arch/aarch64/core/isr.h
@@ -1,0 +1,31 @@
+/** @file */
+#ifndef CORE_ISR_H
+#define CORE_ISR_H
+
+#include <stdint.h>
+
+/// This type represents an interrupt handler.
+typedef void (*isr_handler_t)();
+
+/**
+ * Initializes the _Interrupt Service Routine_ (ISR).
+ */
+void isr_init();
+
+/**
+ * Enables hardware interrupts.
+ */
+void isr_enable_interrupts();
+
+/**
+ * Disables hardware interrupts.
+ */
+void isr_disable_interrupts();
+
+void isr_irq_handler();
+
+void isr_exception_handler(uint8_t type);
+
+void isr_register_handler(uint32_t id, isr_handler_t handler);
+
+#endif


### PR DESCRIPTION
The systme timer uses interrupts so let's start a ISR implementation
that looks like the x86_64 one so that we might come up with a common
implementation in the end.