### PR TITLE
kernel: aarch64: fix kmain() declaration

### DIFF
--- a/src/kernel/arch/aarch64/kmain.h
+++ b/src/kernel/arch/aarch64/kmain.h
@@ -2,9 +2,11 @@
 #ifndef AARCH64_KMAIN_H
 #define AARCH64_KMAIN_H
 
+#include <stdint.h>
+
 /**
  * This is the entrypoint of the kernel (C code).
  */
-void kmain() __asm__("kmain");
+void kmain(uintptr_t w0) __asm__("kmain");
 
 #endif


### PR DESCRIPTION
Fixes https://github.com/willdurand/ArvernOS/issues/503