### PR TITLE
kernel: x86_64: fix compilation error in non-selfhosting mode

### DIFF
--- a/src/kernel/arch/x86_64/arch/kernel.c
+++ b/src/kernel/arch/x86_64/arch/kernel.c
@@ -1,5 +1,6 @@
 #include <arch/kernel.h>
 
+#include <arvern/utils.h>
 #include <core/isr.h>
 #include <core/port.h>
 #include <drivers/vga_text.h>
@@ -42,5 +43,7 @@ void arch_poweroff(int exit_code)
   } else {
     port_byte_out(0x501, exit_code);
   }
+#else
+  UNUSED(exit_code);
 #endif
 }


### PR DESCRIPTION
Fixes https://github.com/willdurand/ArvernOS/issues/542