### PR TITLE
kernel: sys: add openat() syscall stub-ish

### DIFF
--- a/include/kernel/sys/k_syscall.h
+++ b/include/kernel/sys/k_syscall.h
@@ -46,5 +46,6 @@ int k_gethostbyname2(const char* name, struct in_addr* in);
 int k_execv(const char* path, char* const argv[]);
 pid_t k_getpid();
 void k_exit(int code);
+int k_openat(int dirfd, const char* pathname, int flags);
 
 #endif

--- a/include/libc/fcntl.h
+++ b/include/libc/fcntl.h
@@ -22,4 +22,7 @@
 /// Set file descriptor offset to EOF plus offset.
 #define SEEK_END 2
 
+/// SYSCALL_OPENAT should use the current working directory.
+#define AT_FDCWD -100
+
 #endif

--- a/include/libc/sys/syscall.h
+++ b/include/libc/sys/syscall.h
@@ -27,6 +27,7 @@
 #define SYSCALL_EXECV          14
 #define SYSCALL_GETPID         15
 #define SYSCALL_EXIT           16
+#define SYSCALL_OPENAT         17
 
 #define SYSCALL_SET_ERRNO()                                                    \
   if (retval < 0) {                                                            \
@@ -205,5 +206,16 @@ pid_t getpid();
  * @param code the status code
  */
 void exit(int code);
+
+/**
+ * Implements the openat syscall.
+ *
+ * @param dirfd a directory file descriptor
+ * @param pathname the name of the file to open
+ * @param flags creation or file status flags
+ * @return a file descriptor, i.e. a small, non-negative integer that is used
+ * in subsequent system calls
+ */
+int openat(int dirfd, const char* pathname, int flags);
 
 #endif

--- a/src/kernel/sys/k_openat.c
+++ b/src/kernel/sys/k_openat.c
@@ -1,0 +1,15 @@
+#include <sys/k_syscall.h>
+
+#include <errno.h>
+#include <fcntl.h>
+
+int k_openat(int dirfd, const char* pathname, int flags)
+{
+  if (dirfd == AT_FDCWD) {
+    return k_open(pathname, flags);
+  }
+
+  // TODO: Add better support for `dirfd` and other AT_* special values.
+
+  return -EBADF;
+}

--- a/src/kernel/sys/k_syscall.c
+++ b/src/kernel/sys/k_syscall.c
@@ -6,7 +6,9 @@
 
 typedef void (*syscall_ptr_t)(void);
 
-syscall_ptr_t syscall_handlers[200] = { (syscall_ptr_t)k_not_implemented };
+syscall_ptr_t syscall_handlers[300] = {
+  [0 ... 299] = (syscall_ptr_t)k_not_implemented,
+};
 
 void syscall_init()
 {
@@ -28,6 +30,7 @@ void syscall_init()
   syscall_handlers[SYSCALL_EXECV] = (syscall_ptr_t)k_execv;
   syscall_handlers[SYSCALL_GETPID] = (syscall_ptr_t)k_getpid;
   syscall_handlers[SYSCALL_EXIT] = (syscall_ptr_t)k_exit;
+  syscall_handlers[SYSCALL_OPENAT] = (syscall_ptr_t)k_openat;
 
   arch_syscall_init();
 }

--- a/src/libc/sys/openat.c
+++ b/src/libc/sys/openat.c
@@ -1,0 +1,14 @@
+#include <sys/syscall.h>
+
+int openat(int dirfd, const char* pathname, int flags)
+{
+#ifdef __is_libk
+  return k_openat(dirfd, pathname, flags);
+#else
+  int retval = syscall(SYSCALL_OPENAT, dirfd, pathname, flags);
+
+  SYSCALL_SET_ERRNO();
+
+  return retval;
+#endif
+}


### PR DESCRIPTION
This implementation only handles AT_FDCWD, which behaves like open().