### PR TITLE
kernel: net: slightly refactor the network interfaces

### DIFF
--- a/include/kernel/net/net.h
+++ b/include/kernel/net/net.h
@@ -29,19 +29,32 @@ typedef struct net_interface net_interface_t;
 
 struct net_driver
 {
+  /// The hardware type (see `ARP_HTYPE_*` values `kernel/net/arp.h`).
+  uint16_t type;
+  /// The name of the driver.
+  const char name[50];
+  /// The interface bound to this driver.
   net_interface_t* interface;
-  const char* (*get_name)();
+  /// This function returns the MAC address of the device.
   uint8_t* (*get_mac_address)();
-  void (*transmit_frame)(void* data, uint32_t len);
-  void (*receive_frame)(net_interface_t* interface,
-                        uint8_t* data,
-                        uint32_t len);
+  /// This function is used to transmit data.
+  void (*transmit_frame)(uint8_t* data, uint32_t len);
 };
 
 struct net_interface
 {
-  net_driver_t* driver;
+  /// The interface identifier.
   uint8_t id;
+  /// The hardware type of the interface.
+  uint16_t hardware_type;
+  /// The driver bound to this interface.
+  net_driver_t* driver;
+  /// The callback used by the driver to transfer the received data to the
+  /// upper layers.
+  void (*receive_frame_callback)(net_interface_t* interface,
+                                 uint8_t* data,
+                                 uint32_t len);
+  // Network configuration.
   uint8_t mac[6];
   uint8_t ip[4];
   uint8_t gateway_mac[6];

--- a/src/kernel/kshell/net.c
+++ b/src/kernel/kshell/net.c
@@ -17,7 +17,7 @@ void net()
   char buf[16];
 
   printf("eth%d:\n", in_id);
-  printf("  driver : %s\n", in->driver->get_name());
+  printf("  driver : %s\n", in->driver->name);
   inet_itoa(in->ip, buf, 16);
   printf("  ip     : %s\n", buf);
   printf("  mac    : %02x:%02x:%02x:%02x:%02x:%02x\n",

--- a/src/kernel/net/arp.c
+++ b/src/kernel/net/arp.c
@@ -20,7 +20,7 @@ void arp_request(net_interface_t* interface, uint8_t ip[4])
 
   // Create ARP packet.
   arp_packet_t arp_packet = {
-    .hardware_type = htons(ARP_HTYPE_ETHERNET),
+    .hardware_type = htons(interface->hardware_type),
     .protocol_type = htons(ETHERTYPE_IPV4),
     .hardware_size = 6,
     .protocol_size = 4,

--- a/src/kernel/net/net.c
+++ b/src/kernel/net/net.c
@@ -22,14 +22,22 @@ void net_interface_init(uint8_t interface_id,
     return;
   }
 
+  if (driver->type != ARP_HTYPE_ETHERNET) {
+    NET_DEBUG("no support for hardware type other than Ethernet 802.3: "
+              "hardware_type=%d",
+              driver->type);
+    return;
+  }
+
   NET_DEBUG("initializing interface id=%d with driver='%s'",
             interface_id,
-            driver->get_name());
+            driver->name);
 
   net_interface_t* in = calloc(1, sizeof(net_interface_t));
   in->id = interface_id;
   in->driver = driver;
-  in->driver->receive_frame = ethernet_receive_frame;
+  in->hardware_type = driver->type;
+  in->receive_frame_callback = ethernet_receive_frame;
   in->driver->interface = in;
   memcpy(in->mac, in->driver->get_mac_address(), 6);
 


### PR DESCRIPTION
- The driver does not need to have a `receive` function, it can call a
  method of the interface.
- Add hardware type on both `net_driver_t` and `net_interface_t` because
  that is useful and we only support Ethernet 802.3 so far.