### PR TITLE
kernel: x86_64: do not use iretq for context switching (yet)

### DIFF
--- a/src/kernel/arch/x86_64/arch/proc.c
+++ b/src/kernel/arch/x86_64/arch/proc.c
@@ -44,23 +44,16 @@ task_t* arch_task_create(uint64_t clone_flags, uintptr_t entrypoint)
 
   uintptr_t* rsp = (uintptr_t*)((uintptr_t)p + PAGE_SIZE);
 
-  // Prepare an interrupt frame for `iretq` called in `ret_from_fork`.
-  // See: src/kernel/arch/x86_64/asm/proc.asm
-  *--rsp = KERNEL_BASE_SELECTOR + 0x08; // ss
-  *--rsp = 0;                           // rsp
-  *--rsp = 0x202;                       // cpu flags
-  *--rsp = KERNEL_BASE_SELECTOR;        // cs
-  *--rsp = (uintptr_t)entrypoint;       // rip
-
-  // This will be used in `arch_task_switch` to call `ret_from_fork`.
-  *--rsp = (uintptr_t)ret_from_fork;
-  *--rsp = 0;     // rbp
-  *--rsp = 0;     // rbx
-  *--rsp = 0;     // r12
-  *--rsp = 0;     // r13
-  *--rsp = 0;     // r14
-  *--rsp = 0;     // r15
-  *--rsp = 0x202; // cpu flags
+  *--rsp = (uintptr_t)entrypoint;
+  *--rsp = (uintptr_t)ret_from_fork; // This will be used in `arch_task_switch`
+                                     // to call `ret_from_fork`.
+  *--rsp = 0;                        // rbp
+  *--rsp = 0;                        // rbx
+  *--rsp = 0;                        // r12
+  *--rsp = 0;                        // r13
+  *--rsp = 0;                        // r14
+  *--rsp = 0;                        // r15
+  *--rsp = 0x202;                    // cpu flags
 
   p->info.rsp = (uintptr_t)rsp;
 

--- a/src/kernel/arch/x86_64/asm/proc.asm
+++ b/src/kernel/arch/x86_64/asm/proc.asm
@@ -24,7 +24,9 @@ arch_task_switch:
   ret
 
 ret_from_fork:
+  pop r12
+
   extern task_schedule_tail
   call task_schedule_tail
-  cli
-  iretq
+
+  call r12

--- a/src/kernel/kshell/selftest.c
+++ b/src/kernel/kshell/selftest.c
@@ -40,9 +40,6 @@ int selftest()
     free(str);
   }
 
-  // TODO: On x86_64, there is an error in the MMU, which occurs now that we
-  // have multi-tasking.
-#ifndef __x86_64__
   printf("now allocating a large chunk of memory... ");
   printf("Pointer before malloc() = %p\n", str);
   str = (char*)malloc(1024 * 1024 * 5 * sizeof(char));
@@ -54,7 +51,6 @@ int selftest()
     printf("success!\n");
     free(str);
   }
-#endif
 
   print_selftest_header("filesystem");
   inode_t debug = vfs_namei("/dev/debug");


### PR DESCRIPTION
Fixes #588