### PR TITLE
kernel: core: move ELF loader to shared code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ libc_asm_objects   = $(patsubst %.asm, $(lib_objs_dir)/%.o, $(libc_asm_files))
 # libk
 libk_c_files       += $(wildcard $(kernel_src_dir)/*.c)
 libk_c_files       += $(wildcard $(kernel_src_dir)/config/*.c)
+libk_c_files       += $(wildcard $(kernel_src_dir)/core/elf.c)
 libk_c_files       += $(wildcard $(kernel_src_dir)/core/isr.c)
 libk_c_files       += $(wildcard $(kernel_src_dir)/fs/*.c)
 libk_c_files       += $(wildcard $(kernel_src_dir)/fs/dev/*.c)

--- a/include/kernel/core/elf.h
+++ b/include/kernel/core/elf.h
@@ -1,6 +1,10 @@
 /**
  * @file
  * @see https://www.uclibc.org/docs/elf-64-gen.pdf
+ * @see https://man7.org/linux/man-pages/man5/elf.5.html
+ *
+ * This header file contains the definitions of the Executable and Linking
+ * Format (ELF) for both 32 (arm) and 64 bits (the default).
  */
 #ifndef CORE_ELF_H
 #define CORE_ELF_H
@@ -34,15 +38,29 @@
 /// Identifies a section that occupies memory during process execution.
 #define ELF_SECTION_FLAG_ALLOC 0x2
 
+#ifdef __arm__
+
+#define ElfN_Addr uint32_t
+#define ElfN_Off  uint32_t
+#define ElfN_Size uint32_t
+
+#else // __arm__
+
+#define ElfN_Addr uint64_t
+#define ElfN_Off  uint64_t
+#define ElfN_Size uint64_t
+
+#endif
+
 typedef struct elf_header
 {
   unsigned char identity[16];
   uint16_t type;
   uint16_t machine;
   uint32_t version;
-  uint64_t entry;
-  uint64_t ph_offset;
-  uint64_t sh_offset;
+  ElfN_Addr entry;
+  ElfN_Off ph_offset;
+  ElfN_Off sh_offset;
   uint32_t flags;
   uint16_t header_size;
   uint16_t ph_size;
@@ -55,27 +73,32 @@ typedef struct elf_header
 typedef struct elf_program_header
 {
   uint32_t type;
+#ifndef __arm__
   uint32_t flags;
-  uint64_t offset;
-  uint64_t virtual_address;
-  uint64_t physical_address;
-  uint64_t file_size;
-  uint64_t mem_size;
-  uint64_t align;
+#endif
+  ElfN_Off offset;
+  ElfN_Addr virtual_address;
+  ElfN_Addr physical_address;
+  ElfN_Size file_size;
+  ElfN_Size mem_size;
+#ifdef __arm__
+  ElfN_Size flags;
+#endif
+  ElfN_Size align;
 } __attribute__((packed)) elf_program_header_t;
 
 typedef struct elf_section_header
 {
-  uint32_t name;            ///< Section name
-  uint32_t type;            ///< Section type
-  uint64_t flags;           ///< Section attributes
-  uint64_t virtual_address; ///< Virtual address in memory
-  uint64_t offset;          ///< Offset in file
-  uint64_t size;            ///< Size of section
-  uint32_t link;            ///< Link to other section
-  uint32_t info;            ///< Miscellaneous information
-  uint64_t addralign;       ///< Address alignment boundary
-  uint64_t entsize;         ///< Size of entries, if section has table
+  uint32_t name;             ///< Section name
+  uint32_t type;             ///< Section type
+  ElfN_Size flags;           ///< Section attributes
+  ElfN_Addr virtual_address; ///< Virtual address in memory
+  ElfN_Off offset;           ///< Offset in file
+  ElfN_Size size;            ///< Size of section
+  uint32_t link;             ///< Link to other section
+  uint32_t info;             ///< Miscellaneous information
+  ElfN_Size addralign;       ///< Address alignment boundary
+  ElfN_Size entsize;         ///< Size of entries, if section has table
 } __attribute__((packed)) elf_section_header_t;
 
 elf_header_t* elf_load(uint8_t* data);

--- a/src/kernel/core/elf.c
+++ b/src/kernel/core/elf.c
@@ -1,25 +1,27 @@
-#include "elf.h"
+#include <core/elf.h>
 #include <core/logging.h>
 #include <inttypes.h>
-#include <mmu/paging.h>
 #include <string.h>
 
-int get_elf_type(elf_header_t* elf);
-void load_segment(uint8_t* data, elf_program_header_t* program_header);
+#ifdef __x86_64__
+#include <mmu/paging.h>
+#endif
+
+int elf_get_type(elf_header_t* elf);
+void elf_load_segment(uint8_t* data, elf_program_header_t* program_header);
 
 elf_header_t* elf_load(uint8_t* data)
 {
   elf_header_t* elf = (elf_header_t*)data;
 
-  if (get_elf_type(elf) != ELF_TYPE_EXECUTABLE) {
+  if (elf_get_type(elf) != ELF_TYPE_EXECUTABLE) {
     CORE_DEBUG("%s", "not an executable");
-    return 0;
+    return NULL;
   }
 
   CORE_DEBUG(
     "file header: machine=%#x version=%#x type=%d entry=%p header_size=%u"
-    " ph_size=%u ph_num=%d ph_offset=%" PRIu64 " sh_size=%u sh_num=%d"
-    " sh_offset=%" PRIu64 " strtab_index=%d",
+    " ph_size=%u ph_num=%d sh_size=%u sh_num=%d strtab_index=%d",
     elf->machine,
     elf->version,
     elf->type,
@@ -27,22 +29,20 @@ elf_header_t* elf_load(uint8_t* data)
     elf->header_size,
     elf->ph_size,
     elf->ph_num,
-    elf->ph_offset,
     elf->sh_size,
     elf->sh_num,
-    elf->sh_offset,
     elf->strtab_index);
 
   elf_program_header_t* program_header =
-    (elf_program_header_t*)((uint64_t)data + elf->ph_offset);
+    (elf_program_header_t*)((uintptr_t)data + elf->ph_offset);
 
-  for (uint64_t i = 0; i < elf->ph_num; i++) {
-    CORE_DEBUG("program header: type=%d addr=%p",
+  for (uint16_t i = 0; i < elf->ph_num; i++) {
+    CORE_DEBUG("program header: type=%" PRIu32 " addr=%p",
                program_header[i].type,
                program_header[i].virtual_address);
 
     if (program_header[i].type == ELF_PROGRAM_TYPE_LOAD) {
-      load_segment(data, &program_header[i]);
+      elf_load_segment(data, &program_header[i]);
     }
   }
 
@@ -51,7 +51,7 @@ elf_header_t* elf_load(uint8_t* data)
   return elf;
 }
 
-int get_elf_type(elf_header_t* elf)
+int elf_get_type(elf_header_t* elf)
 {
   int iself = -1;
 
@@ -64,7 +64,9 @@ int get_elf_type(elf_header_t* elf)
     CORE_DEBUG("%s", "validating elf structs");
 
     if (elf->header_size != sizeof(elf_header_t)) {
-      CORE_DEBUG("%s", "invalid elf header size");
+      CORE_DEBUG("invalid elf header size: %d, expected: %d",
+                 elf->header_size,
+                 sizeof(elf_header_t));
 
       iself = -1;
     } else if (elf->ph_size != sizeof(elf_program_header_t)) {
@@ -81,13 +83,18 @@ int get_elf_type(elf_header_t* elf)
   return iself;
 }
 
-void load_segment(uint8_t* data, elf_program_header_t* program_header)
+void elf_load_segment(uint8_t* data, elf_program_header_t* program_header)
 {
-  uint64_t mem_size = program_header->mem_size;    // Size in memory
-  uint64_t file_size = program_header->file_size;  // Size in file
-  uint64_t addr = program_header->virtual_address; // Offset in memory
-  uint64_t offset = program_header->offset;        // Offset in file
+  ElfN_Size mem_size = program_header->mem_size;    // Size in memory
+  ElfN_Size file_size = program_header->file_size;  // Size in file
+  ElfN_Addr addr = program_header->virtual_address; // Address in memory
+  ElfN_Off offset = program_header->offset;         // Offset in file
 
+  if (mem_size == 0) {
+    return;
+  }
+
+#ifdef __x86_64__
   // We need WRITABLE because we copy data right after.
   uint32_t flags =
     PAGING_FLAG_PRESENT | PAGING_FLAG_USER_ACCESSIBLE | PAGING_FLAG_WRITABLE;
@@ -102,11 +109,8 @@ void load_segment(uint8_t* data, elf_program_header_t* program_header)
   uint64_t start_page = page_containing_address(addr);
   uint32_t number_of_pages = paging_amount_for_byte_size(addr, mem_size);
 
-  if (mem_size == 0) {
-    return;
-  }
-
   map_multiple(start_page, number_of_pages, flags);
+#endif
 
   memcpy((void*)addr, data + offset, file_size);
   memset((void*)(addr + file_size), 0, mem_size - file_size);
@@ -118,21 +122,23 @@ void load_segment(uint8_t* data, elf_program_header_t* program_header)
 void elf_unload(elf_header_t* elf)
 {
   elf_program_header_t* program_header =
-    (elf_program_header_t*)((uint64_t)elf + elf->ph_offset);
+    (elf_program_header_t*)((uintptr_t)elf + elf->ph_offset);
 
-  for (uint64_t i = 0; i < elf->ph_num; i++) {
+  for (uint16_t i = 0; i < elf->ph_num; i++) {
     if (program_header[i].type == ELF_PROGRAM_TYPE_LOAD) {
-      uint64_t mem_size = program_header[i].mem_size;
-      uint64_t addr = program_header[i].virtual_address;
-
-      uint64_t start_page = page_containing_address(addr);
-      uint32_t number_of_pages = paging_amount_for_byte_size(addr, mem_size);
+      ElfN_Size mem_size = program_header[i].mem_size;
 
       if (mem_size == 0) {
         continue;
       }
 
+#ifdef __x86_64__
+      uint64_t addr = program_header[i].virtual_address;
+      uint64_t start_page = page_containing_address(addr);
+      uint32_t number_of_pages = paging_amount_for_byte_size(addr, mem_size);
+
       unmap_multiple(start_page, number_of_pages);
+#endif
     }
   }
 


### PR DESCRIPTION
Kinda fixes https://github.com/willdurand/ArvernOS/issues/540

---

This is not quite correct for non-x86_64 architectures but that's a start at least...